### PR TITLE
Change Content-Type in easy.c

### DIFF
--- a/easy.c
+++ b/easy.c
@@ -9,7 +9,7 @@ main(void)
     if (pledge("stdio", NULL) == -1) 
         err(EXIT_FAILURE, "pledge");
     puts("Status: 200 OK\r");
-    puts("Content-Type: text/html\r");
+    puts("Content-Type: text/plain\r");
     puts("\r");
     puts("Hello, world!\n");
     return EXIT_SUCCESS;


### PR DESCRIPTION
I think `text/plain` better matches the content which is actually being output.