### PR TITLE
Add final instruction to check the CGI URL

### DIFF
--- a/easy.xml
+++ b/easy.xml
@@ -142,7 +142,8 @@
 								Compiles the script.  Installs it.
 								Makes sure <a href="https://man.openbsd.org/slowcgi.8">slowcgi(8)</a> and of
 								course <a href="https://man.openbsd.org/httpd.8">httpd(8)</a> are running.
-								Done.
+								Now visit <a href="http://localhost/cgi-bin/cgi">http://localhost/cgi-bin/cgi</a>
+								to confirm it works. Done.
 							</p>
 							<p>
 								Want more examples?


### PR DESCRIPTION
This clarifies the URL to visit as it may not be immediately clear to new users that their CGI application is not presented in the root.